### PR TITLE
Update transfer-bar-add.js

### DIFF
--- a/transfer-bar-add.js
+++ b/transfer-bar-add.js
@@ -10,10 +10,10 @@
 
 function transferLoadCalculator(){
     let transferLoadNumArray = [];
-    document.querySelectorAll('.operators__busy').forEach((transferHEElement)=>{
+    document.querySelectorAll('.operators__busy.hasName').forEach((transferHEElement)=>{
         let transferInfoRaw = transferHEElement.firstElementChild.getAttribute('title');
         let transferLoadPos = transferInfoRaw.indexOf('Load: ');
-        var transferLoadNum = transferInfoRaw.substr(transferLoadPos+6, 1);
+        let transferLoadNum = transferInfoRaw.substr(transferLoadPos+6, 1);
         transferLoadNumArray.push(parseInt(transferLoadNum,10))
     })
     let transferLoadFinal = transferLoadNumArray.reduce((a,b) => a+b, 0)
@@ -21,10 +21,10 @@ function transferLoadCalculator(){
 }
 function transferThrottleCalculator(){
     let transferThrottleArray =[];
-    document.querySelectorAll('.operators__busy').forEach((transferHEElement)=>{
+    document.querySelectorAll('.operators__busy.hasName').forEach((transferHEElement)=>{
         let transferInfoRaw = transferHEElement.firstElementChild.getAttribute('title');
         let transferThrottlePos = transferInfoRaw.indexOf('Throttle: ');
-        var transferThrottleNum = transferInfoRaw.substr(transferThrottlePos+10, 1);
+        let transferThrottleNum = transferInfoRaw.substr(transferThrottlePos+10, 1);
         transferThrottleArray.push( parseInt(transferThrottleNum,10));
     })
     let transferThrottleFinal = transferThrottleArray.reduce((a,b) => a+b, 0)
@@ -41,6 +41,7 @@ window.setInterval(function(){
     if (transferBubble === null){
         transferBarAdd()
     }else{
-    transferBubble.innerHTML = `${transferLoadCalculator()} / ${transferThrottleCalculator()}`;
+    let transferAvailabilityCaculator = transferThrottleCalculator() - transferLoadCalculator();
+    transferBubble.innerHTML = `${transferAvailabilityCaculator} / ${transferThrottleCalculator()}`;
     }
 }, 5000);


### PR DESCRIPTION
Adjusting the final transferBubble to match the format of the other bubbles.  I originally had it switched where I was showing how many chats all operators have, but it should actually be showing the number of available spaces.  This change takes that into account. 

For example, if I have an availability of 3 and one current chat:

Original: 1/3
Change: 2/3

![Screen Shot on 2020-09-05 at 21:30:59](https://user-images.githubusercontent.com/24914028/92305130-31b5a000-efbf-11ea-970a-af24df97eaa9.png)
